### PR TITLE
use fork of kernel/google-modules/gpu

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -49,7 +49,7 @@
   <project path="private/google-modules/fingerprint/fpc" name="kernel/google-modules/fingerprint/fpc" groups="partner" />
   <project path="private/google-modules/fingerprint/qcom/qfs4008" name="kernel/google-modules/fingerprint/qcom/qfs4008" groups="partner" />
   <project path="private/google-modules/gps/broadcom/bcm47765" name="kernel/google-modules/gps/broadcom/bcm47765" groups="partner" />
-  <project path="private/google-modules/gpu" name="kernel/google-modules/gpu" groups="partner" />
+  <project path="private/google-modules/gpu" name="kernel_google-modules_gpu-zumapro" groups="partner" remote="grapheneos" />
   <project path="private/google-modules/gxp/gs201" name="kernel/google-modules/gxp/gs201" groups="partner" />
   <project path="private/google-modules/gxp/zuma" name="kernel_google-modules_gxp_zuma" groups="partner" remote="grapheneos" />
   <project path="private/google-modules/hdcp/samsung" name="kernel/google-modules/hdcp/samsung" groups="partner" />


### PR DESCRIPTION
Depends on https://github.com/GrapheneOS/kernel_google-modules_gpu-zumapro, which upgrades the ARM Mali GPU driver version from r49 (15 QPR1) to r51 (15 QPR2 Beta 1).

15 QPR2 Beta 1 driver version contains the fix for a severe device stalling issue: https://github.com/GrapheneOS/kernel_google-modules_gpu-zumapro/commit/62a4acbf2789f7dde2884363b1b0dddde8d0cf88. That issue affects the 15 QPR1 version when it's used with 6.1.118 GKI.

